### PR TITLE
plus2e: Enable USE_XML_AUDIO_POLICY_CONF

### DIFF
--- a/plus2e/device.mk
+++ b/plus2e/device.mk
@@ -97,6 +97,8 @@ PRODUCT_PACKAGES += \
     android.hardware.audio.effect@all-versions-impl \
     android.hardware.bluetooth.a2dp@1.0-impl
 
+USE_XML_AUDIO_POLICY_CONF := 1
+
 PRODUCT_PACKAGES += \
     libGLES_mesa \
     hwcomposer.drm \


### PR DESCRIPTION
android-q supports only xml audio policy configuration.

Signed-off-by: Roman Stratiienko <roman.stratiienko@globallogic.com>